### PR TITLE
Disable callback features in 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,18 @@ language: julia
 julia:
   - nightly
   - release
-
+sudo: required
+dist: trusty
 before_install:
-  - sudo apt-add-repository -y "deb http://packages.ros.org/ros/ubuntu precise main"
+  - sudo apt-add-repository -y "deb http://packages.ros.org/ros/ubuntu trusty main"
   - wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
   - sudo apt-get update
-  - sudo apt-get -y install ros-hydro-ros-base ros-hydro-common-msgs
+  - sudo apt-get -y install ros-indigo-ros-base ros-indigo-common-msgs
   - sudo rosdep init
   - rosdep update
 before_script:
-  - source /opt/ros/hydro/setup.sh
+  - export PATH=/usr/bin:$PATH
+  - source /opt/ros/indigo/setup.sh
   - roscore &
   - sleep 5
   - python test/echonode.py &

--- a/src/pubsub.jl
+++ b/src/pubsub.jl
@@ -17,13 +17,21 @@ function publish{MsgType<:MsgT}(p::Publisher{MsgType}, msg::MsgType)
     pycall(p.o["publish"], PyAny, convert(PyObject, msg))
 end
 
+if VERSION >= v"0.5.0-dev+3692" #callbacks are broken
+
+type Subscriber{T}
+end
+Subscriber(args...) = error(
+"""Subscribing to a topic is currently broken on julia v0.5 and above. See
+https://github.com/jdlangs/RobotOS.jl/issues/15 for ongoing efforts to fix this.""")
+
+else #callbacks not broken
+
 type Subscriber{MsgType<:MsgT}
     o::PyObject
     callback
 
-    function Subscriber(
-        topic::AbstractString, cb, cb_args::Tuple=(); kwargs...
-    )
+    function Subscriber(topic::AbstractString, cb, cb_args::Tuple=(); kwargs...)
         @debug("Creating <$(string(MsgType))> subscriber on topic: '$topic'")
         rospycls = _get_rospy_class(MsgType)
         jl_cb(msg::PyObject) = cb(convert(MsgType, msg), cb_args...)
@@ -33,6 +41,7 @@ type Subscriber{MsgType<:MsgT}
         )
     end
 end
+
 Subscriber{MsgType<:MsgT}(
     topic::AbstractString,
     ::Type{MsgType},
@@ -40,3 +49,5 @@ Subscriber{MsgType<:MsgT}(
     cb_args::Tuple=();
     kwargs...
 ) = Subscriber{MsgType}(ascii(topic), cb, cb_args; kwargs...)
+
+end #version check

--- a/src/services.jl
+++ b/src/services.jl
@@ -32,6 +32,17 @@ end
     resp
 end
 
+if VERSION >= v"0.5.0-dev+3692" #callbacks are broken
+
+type Service{T}
+end
+
+Service(args...) = error(
+"""Providing a service is currently broken on julia v0.5 and above. See
+https://github.com/jdlangs/RobotOS.jl/issues/15 for ongoing efforts to fix this.""")
+
+else #callbacks not broken
+
 type Service{SrvType <: ServiceDefinition}
     o::PyObject
     jl_handler
@@ -63,6 +74,8 @@ function Service{SrvType<:ServiceDefinition}(
 )
     Service{SrvType}(ascii(name), handler; kwargs...)
 end
+
+end #version check
 
 function wait_for_service(service::AbstractString; kwargs...)
     try

--- a/test/pubsub.jl
+++ b/test/pubsub.jl
@@ -14,29 +14,48 @@ for i=1:Nmsgs
     refs[i] = Vector3(rand(3)...)
 end
 
+const ros_pub = Publisher("vectors", Vector3, queue_size = 10)
+rossleep(Duration(3.0))
+
+function publish_messages(pubobj, msgs, rate_hz)
+    const r = Rate(rate_hz)
+    for msg in msgs
+        publish(pubobj, msg)
+        rossleep(r)
+    end
+    rossleep(Duration(1.0))
+end
+
 function pose_cb(msg::PoseStamped, msgs::Vector{PoseStamped})
     mtime = to_nsec(msg.header.stamp) - t0
-    println("Message received, time: ",mtime," nanoseconds")
-    if msg.header.stamp.secs > 1.
+    mtime > 0 && println("Message received, time: ",mtime," nanoseconds")
+    if msg.header.stamp.secs > 1.0
         push!(msgs, msg)
         println("Got message #",msg.header.seq)
     end
 end
-pose_cb(PoseStamped(), msgs)
+pose_cb(PoseStamped(), msgs) #warm up run
 
-const ros_pub = Publisher("vectors", Vector3, queue_size = 10)
+if VERSION >= v"0.5.0-dev+3692" #callbacks are broken
+
+warn("Not testing subscriber!")
+
+publish_messages(ros_pub, refs, 20.0)
+rossleep(Duration(5.0))
+Nreceived = get_param("/num_received_messages")
+@test Nreceived == length(refs)
+set_param("/num_received_messages", 0)
+
+else #callbacks not broken
+
 const ros_sub = Subscriber("poses", PoseStamped, pose_cb, (msgs,), queue_size = 10)
 
 #First message doesn't go out for some reason
 publish(ros_pub, Vector3(1.1,2.2,3.3))
 rossleep(Duration(1.0))
-
-const r = Rate(20.0)
-for i=1:Nmsgs
-    publish(ros_pub, refs[i])
-    rossleep(r)
-end
+publish_messages(ros_pub, refs, 20.0)
 rossleep(Duration(1.0))
+
 println("Received ",length(msgs)," / ",Nmsgs)
 
 @test length(msgs) == Nmsgs
@@ -45,3 +64,6 @@ for i=1:Nmsgs
     @test_approx_eq msgs[i].pose.position.y refs[i].y
     @test_approx_eq msgs[i].pose.position.z refs[i].z
 end
+empty!(msgs)
+
+end #version check

--- a/test/services.jl
+++ b/test/services.jl
@@ -3,11 +3,11 @@
 using std_srvs.srv
 using nav_msgs.srv
 
-const flag = Bool[false]
-const Nposes = 5
-empty!(msgs)
-
 #Set up services
+const srvcall = ServiceProxy("callme", SetBool)
+println("Waiting for 'callme' service...")
+wait_for_service("callme")
+
 function srv_cb(req::GetPlanRequest)
     println("GetPlan call received")
     @test_approx_eq(req.start.pose.position.x, 1.0)
@@ -24,14 +24,27 @@ function srv_cb(req::GetPlanRequest)
     return resp
 end
 
-const srvcall = ServiceProxy("callme", Empty)
+if VERSION >= v"0.5.0-dev+3692" #callbacks are broken
+
+warn("Not testing service provider!")
+
+println("Calling service...")
+srvcall(SetBoolRequest(false))
+rossleep(Duration(5.0))
+
+didcall = get_param("/received_service_call")
+@test didcall
+set_param("/received_service_call", false)
+
+else #callbacks not broken
+
+const flag = Bool[false]
+const Nposes = 5
+
 const srvlisten = Service("getplan", GetPlan, srv_cb)
 
-#Call echo's Empty service
-println("Waiting for 'callme' service...")
-wait_for_service("callme")
-println("Calling service now")
-srvcall(EmptyRequest())
+println("Calling service...")
+srvcall(SetBoolRequest(true))
 
 #Wait for call from echo
 println("Waiting for service call from echo..")
@@ -40,8 +53,8 @@ while ! (flag[1] || is_shutdown())
 end
 println("Response sent")
 
-#Listen for message replies caught by the geomety_msgs/PoseStamped subscriber
-#in pubsub.jl which populates the msgs global variable
+#Check the message replies caught by the geomety_msgs/PoseStamped subscriber in pubsub.jl which
+#populates the msgs global variable
 if flag[1]
     rossleep(Duration(2.0))
     @test length(msgs) == Nposes
@@ -49,7 +62,10 @@ if flag[1]
         @test_approx_eq(msgs[i].pose.position.z, i)
     end
 end
+empty!(msgs)
+
+end #version check
 
 #Test error handling
 @test_throws ErrorException wait_for_service("fake_srv", timeout=1.0)
-@test_throws ArgumentError srvcall(EmptyResponse())
+@test_throws ArgumentError srvcall(SetBoolResponse())

--- a/test/typegeneration.jl
+++ b/test/typegeneration.jl
@@ -4,7 +4,7 @@ using Compat
 
 @rosimport geometry_msgs.msg: PoseStamped, Vector3
 @rosimport visualization_msgs.msg: Marker
-@rosimport std_srvs.srv.Empty
+@rosimport std_srvs.srv: Empty, SetBool
 @rosimport nav_msgs.srv.GetPlan
 @rosimport std_msgs.msg: Empty
 @rosimport std_msgs.msg: Float64, String
@@ -35,8 +35,8 @@ posestamp = geometry_msgs.msg.PoseStamped()
 @test typeof(posestamp.pose.position) == geometry_msgs.msg.Point
 
 #service creation
-emptyreq = std_srvs.srv.EmptyRequest()
-emptyresp = std_srvs.srv.EmptyResponse()
+boolreq = std_srvs.srv.SetBoolRequest()
+boolresp = std_srvs.srv.SetBoolResponse(true, "message")
 planreq = nav_msgs.srv.GetPlanRequest()
 planresp = nav_msgs.srv.GetPlanResponse()
 @test typeof(planreq) == nav_msgs.srv.GetPlanRequest
@@ -77,4 +77,5 @@ emptymsg = std_msgs.msg.Empty()
 @test isdefined(std_msgs.msg, :Float64Msg)
 @test isdefined(std_msgs.msg, :StringMsg)
 @test Publisher{std_msgs.msg.Float64Msg}("x", queue_size=10) != nothing
-@test Subscriber{std_msgs.msg.Float64Msg}("x", x->x, queue_size=10) != nothing
+VERSION < v"0.5.0-dev+3692" &&
+    @test Subscriber{std_msgs.msg.Float64Msg}("x", x->x, queue_size=10) != nothing


### PR DESCRIPTION
This is really just to get the tests passing again even though the package remains crippled.