### PR TITLE
Travis0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: julia
 julia:
+  - 0.4
+  - 0.5
   - nightly
-  - release
 sudo: required
 dist: trusty
 before_install:

--- a/src/pubsub.jl
+++ b/src/pubsub.jl
@@ -1,6 +1,8 @@
 #API for publishing and subscribing to message topics
 export Publisher, Subscriber, publish
 
+using Compat
+
 type Publisher{MsgType<:MsgT}
     o::PyObject
 
@@ -28,7 +30,7 @@ type Subscriber{MsgType<:MsgT}
         @debug("Creating <$(string(MsgType))> subscriber on topic: '$topic'")
         rospycls = _get_rospy_class(MsgType)
 
-        cond = Base.AsyncCondition()
+        cond = Compat.AsyncCondition()
         mqueue = _py_ros_callbacks["MessageQueue"](CB_NOTIFY_PTR, cond.handle)
         subobj = __rospy__[:Subscriber](ascii(topic), rospycls, mqueue["storemsg"]; kwargs...)
 

--- a/src/services.jl
+++ b/src/services.jl
@@ -42,7 +42,7 @@ type Service{SrvType <: ServiceDefinition}
         @debug("Providing <$SrvType> service at '$name'")
         rospycls = _get_rospy_class(SrvType)
 
-        cond = Base.AsyncCondition()
+        cond = Compat.AsyncCondition()
         pysrv = _py_ros_callbacks["ServiceCallback"](CB_NOTIFY_PTR, cond.handle)
 
         srvobj = try


### PR DESCRIPTION
Test on `0.4`, `0.5`, and nightly builds. Followup to #20.

`AsyncCondition` workaround is on `Compat v0.7.17` so `REQUIRE` version bump unnecessary.