### PR TITLE
Add "lunar" to list of possible rosdistros

### DIFF
--- a/test/rospy.jl
+++ b/test/rospy.jl
@@ -4,7 +4,7 @@ init_node("jltest", anonymous=true)
 #Parameters
 @test length(RobotOS.get_param_names()) > 0
 @test has_param("rosdistro")
-@test chomp(get_param("rosdistro")) in ["hydro", "indigo", "jade", "kinetic"]
+@test chomp(get_param("rosdistro")) in ["hydro", "indigo", "jade", "kinetic", "lunar"]
 @test ! has_param("some_param")
 @test_throws KeyError get_param("some_param")
 @test_throws KeyError delete_param("some_param")


### PR DESCRIPTION
Tests otherwise pass for me on Ubuntu 17.04 with ROS Lunar.