### PR TITLE
Allow generated type conversion using PyObject constructor

### DIFF
--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -2,6 +2,7 @@
 
 using Compat
 import Compat: String, Symbol
+using PyCall
 
 export @rosimport, rostypegen, rostypereset
 
@@ -632,6 +633,11 @@ function _get_rospy_class(typ::DataType)
         end
     rospycls
 end
+
+#Overwrite PyCall's default constructor to call the `convert` functions generated here
+PyCall.PyObject(m::AbstractMsg) = convert(PyCall.PyObject, m)
+PyCall.PyObject(s::AbstractSrv) = convert(PyCall.PyObject, s)
+PyCall.PyObject(s::AbstractService) = convert(PyCall.PyObject, s)
 
 _jl_safe_name(name::AbstractString, suffix) = _nameconflicts(name) ?
     string(name,suffix) :

--- a/test/typegeneration.jl
+++ b/test/typegeneration.jl
@@ -48,6 +48,10 @@ pypose = convert(PyObject, posestamp)
 @test pypose[:pose][:position][:x] == 1.
 @test pypose[:pose][:position][:y] == 2.
 @test pypose[:pose][:position][:z] == 3.
+pypose2 = PyObject(posestamp)
+@test pypose2[:pose][:position][:x] == 1.
+@test pypose2[:pose][:position][:y] == 2.
+@test pypose2[:pose][:position][:z] == 3.
 pose2 = convert(geometry_msgs.msg.PoseStamped, pypose)
 @test pose2.pose.position.x == 1.
 @test pose2.pose.position.y == 2.


### PR DESCRIPTION
Didn't realize that `PyCall` provides a default constructor that doesn't just call `convert`.