### PR TITLE
Drop support for Julia 0.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.4
   - 0.5
   - 0.6
   - nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.5
 PyCall 1.11.0
 Compat 0.17.0

--- a/src/pubsub.jl
+++ b/src/pubsub.jl
@@ -53,7 +53,7 @@ type Subscriber{MsgType<:AbstractMsg}
         @debug("Creating <$(string(MT))> subscriber on topic: '$topic'")
         rospycls = _get_rospy_class(MT)
 
-        cond = Compat.AsyncCondition()
+        cond = Base.AsyncCondition()
         mqueue = _py_ros_callbacks["MessageQueue"](CB_NOTIFY_PTR, cond.handle)
         subobj = __rospy__[:Subscriber](ascii(topic), rospycls, mqueue["storemsg"]; kwargs...)
 

--- a/src/services.jl
+++ b/src/services.jl
@@ -58,7 +58,7 @@ type Service{SrvType <: AbstractService}
         @debug("Providing <$ST> service at '$name'")
         rospycls = _get_rospy_class(ST)
 
-        cond = Compat.AsyncCondition()
+        cond = Base.AsyncCondition()
         pysrv = _py_ros_callbacks["ServiceCallback"](CB_NOTIFY_PTR, cond.handle)
 
         srvobj = try

--- a/test/pubsub.jl
+++ b/test/pubsub.jl
@@ -2,7 +2,7 @@
 #works alongside echonode.py
 #typegeneration.jl must be run first
 
-using geometry_msgs.msg
+using .geometry_msgs.msg
 
 const Nmsgs = 10
 const rate = 20. #Hz

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Base.Test
+using PyCall
 using RobotOS
 using Compat
 RobotOS.debug(true)

--- a/test/services.jl
+++ b/test/services.jl
@@ -1,7 +1,7 @@
 #pubsub.jl must be run first
 
-using std_srvs.srv
-using nav_msgs.srv
+using .std_srvs.srv
+using .nav_msgs.srv
 
 #Set up services
 const srvcall = ServiceProxy("callme", SetBool)


### PR DESCRIPTION
This PR is motivated by a Compat deprecation warning for [Compat.AsyncCondition](https://github.com/JuliaLang/Compat.jl/blob/f705a0f083d1dd90eab0f1e64bae9a6645ba0d2b/src/deprecated.jl#L175) on Julia 0.6.