### PR TITLE
Remove deprecations from julia v0.6, drop v0.5 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: julia
 julia:
-  - 0.5
   - 0.6
   - nightly
 sudo: required

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.5
+julia 0.6
 PyCall 1.11.0
-Compat 0.17.0
+Compat 0.34.0

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -4,7 +4,7 @@ function _callback_notify(handle::Ptr{Void})
     ccall(:uv_async_send, Cint, (Ptr{Void},), handle)
 end
 
-const CB_NOTIFY_PTR = cfunction(_callback_notify, Cint, (Ptr{Void},))
+const CB_NOTIFY_PTR = cfunction(_callback_notify, Cint, Tuple{Ptr{Void}})
 
 function _callback_async_loop(rosobj, cond)
     @debug("Spinning up callback loop...")
@@ -15,14 +15,14 @@ function _callback_async_loop(rosobj, cond)
     @debug("Exiting callback loop")
 end
 
-function _run_callbacks{M}(sub::Subscriber{M})
+function _run_callbacks(sub::Subscriber{M}) where M
     while pycall(sub.queue["size"], PyAny) > 0
         msg = pycall(sub.queue["get"], PyObject)
         sub.callback(convert(M, msg), sub.callback_args...)
     end
 end
 
-function _run_callbacks{T}(srv::Service{T})
+function _run_callbacks(srv::Service{T}) where T
     ReqType = _srv_reqtype(T)
 
     req = pycall(srv.cb_interface["get_request"], PyObject)

--- a/src/pubsub.jl
+++ b/src/pubsub.jl
@@ -1,8 +1,6 @@
 #API for publishing and subscribing to message topics
 export Publisher, Subscriber, publish
 
-using Compat
-
 """
     Publisher{T}(topic; kwargs...)
     Publisher(topic, T; kwargs...)
@@ -10,17 +8,17 @@ using Compat
 Create an object to publish messages of type `T` on a topic. Keyword arguments are directly passed
 to rospy.
 """
-type Publisher{MsgType<:AbstractMsg}
+struct Publisher{MsgType<:AbstractMsg}
     o::PyObject
 
-    @compat function (::Type{Publisher{MT}}){MT <: AbstractMsg}(topic::AbstractString; kwargs...)
+    function Publisher{MT}(topic::AbstractString; kwargs...) where MT <: AbstractMsg
         @debug("Creating <$(string(MT))> publisher on topic: '$topic'")
         rospycls = _get_rospy_class(MT)
         return new{MT}(__rospy__[:Publisher](ascii(topic), rospycls; kwargs...))
     end
 end
 
-Publisher{MT<:AbstractMsg}(topic::AbstractString, ::Type{MT}; kwargs...) =
+Publisher(topic::AbstractString, ::Type{MT}; kwargs...) where {MT <: AbstractMsg} =
     Publisher{MT}(ascii(topic); kwargs...)
 
 """
@@ -28,7 +26,7 @@ Publisher{MT<:AbstractMsg}(topic::AbstractString, ::Type{MT}; kwargs...) =
 
 Publish `msg` on `p`, a `Publisher` with matching message type.
 """
-function publish{MT<:AbstractMsg}(p::Publisher{MT}, msg::MT)
+function publish(p::Publisher{MT}, msg::MT) where MT <: AbstractMsg
     pycall(p.o["publish"], PyAny, convert(PyObject, msg))
 end
 
@@ -40,16 +38,16 @@ Create a subscription to a topic with message type `T` with a callback to use wh
 received, which can be any callable type. Extra arguments provided to the callback when invoked
 can be provided in the `cb_args` tuple. Keyword arguments are directly passed to rospy.
 """
-type Subscriber{MsgType<:AbstractMsg}
+mutable struct Subscriber{MsgType<:AbstractMsg}
     callback
     callback_args::Tuple
     sub_obj::PyObject
     queue::PyObject
     async_loop::Task
 
-    @compat function (::Type{Subscriber{MT}}){MT <: AbstractMsg}(
+    function Subscriber{MT}(
         topic::AbstractString, cb, cb_args::Tuple=(); kwargs...
-    )
+    ) where MT <: AbstractMsg
         @debug("Creating <$(string(MT))> subscriber on topic: '$topic'")
         rospycls = _get_rospy_class(MT)
 
@@ -66,6 +64,6 @@ type Subscriber{MsgType<:AbstractMsg}
     end
 end
 
-function Subscriber{MT<:AbstractMsg}(topic, ::Type{MT}, cb, cb_args::Tuple=(); kwargs...)
+function Subscriber(topic, ::Type{MT}, cb, cb_args::Tuple=(); kwargs...) where MT <: AbstractMsg
     Subscriber{MT}(topic, cb, cb_args; kwargs...)
 end

--- a/test/pubsub.jl
+++ b/test/pubsub.jl
@@ -18,7 +18,7 @@ const ros_pub = Publisher("vectors", Vector3, queue_size = 10)
 rossleep(Duration(3.0))
 
 function publish_messages(pubobj, msgs, rate_hz)
-    const r = Rate(rate_hz)
+    r = Rate(rate_hz)
     for msg in msgs
         publish(pubobj, msg)
         rossleep(r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,9 @@
-using Base.Test
+using Compat.Test
 using PyCall
 using RobotOS
-using Compat
 RobotOS.debug(true)
 
-#Generally, later tests rely on things defined in previous tests, so the order
-#is important
+#Generally, later tests rely on things defined in previous tests, so the order is important
 include("rospy.jl")
 include("time.jl")
 include("typegeneration.jl")

--- a/test/typegeneration.jl
+++ b/test/typegeneration.jl
@@ -1,6 +1,5 @@
 #Tests of proper type generation
 using PyCall
-using Compat
 
 @rosimport geometry_msgs.msg: PoseStamped, Vector3
 @rosimport visualization_msgs.msg: Marker
@@ -14,9 +13,9 @@ using Compat
 @test_throws ErrorException @rosimport nav_msgs.srv.GetPlanRequest
 rostypegen()
 
-@test isdefined(:geometry_msgs)
-@test isdefined(:std_msgs)
-@test isdefined(:nav_msgs)
+@test isdefined(Main, :geometry_msgs)
+@test isdefined(Main, :std_msgs)
+@test isdefined(Main, :nav_msgs)
 @test isdefined(geometry_msgs.msg, :Point)
 @test isdefined(geometry_msgs.msg, :Quaternion)
 @test isdefined(geometry_msgs.msg, :Pose)


### PR DESCRIPTION
Package will now be usable on Julia `v0.6` without deprecation warnings.