### PR TITLE
rostypegen within arbitrary modules (default: Main) for __precompile__ compatibility

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,7 +72,7 @@ regenerated, the first version will remain.
 ### Compatibility with Package Precompilation
 As described above, by default `rostypegen` creates modules in `Main` -- however,
 this behavior is incompatible with Julia package precompilation. If you are using
-`RobotOS` in the context of a module, as opposed to a script, you may reduce
+`RobotOS` in your own module or package, as opposed to a script, you may reduce
 load-time latency (useful for real-life applications!) by generating the ROS type
 modules inside your package module using an approach similar to the example below:
 
@@ -87,20 +87,12 @@ modules inside your package module using an approach similar to the example belo
     import .geometry_msgs.msg: Pose
     # ...
 
-    function __init__()
-        @rosimport geometry_msgs.msg: Pose
-        # ...
-    end
-
     end
 
 In this case, we have provided `rostypegen` with a root module (`MyROSPackage`)
 for type generation. The Julia type corresponding to `geometry_msgs/Pose` now
 lives at `MyROSPackage.geometry_msgs.msg.Pose`; note the extra dot in
-`import .geometry_msgs.msg: Pose`. A precompiled package using `RobotOS` must
-also duplicate any `@rosimport` statements within the `__init__` function in
-its module so that necessary memory/objects in the Python runtime can be
-allocated each time the package is used.
+`import .geometry_msgs.msg: Pose`.
 
 ## Usage: ROS API
 

--- a/src/gentypes.jl
+++ b/src/gentypes.jl
@@ -352,7 +352,7 @@ end
 function _importexprs(mod::ROSMsgModule, rosrootmod::Module)
     imports = Expr[Expr(:import, :RobotOS, :AbstractMsg)]
     othermods = filter(d -> d != _name(mod), mod.deps)
-    append!(imports, [Expr(:using,Symbol(rosrootmod),Symbol(m),:msg) for m in othermods])
+    append!(imports, [Expr(:using,fullname(rosrootmod)...,Symbol(m),:msg) for m in othermods])
     imports
 end
 function _importexprs(mod::ROSSrvModule, rosrootmod::Module)
@@ -362,7 +362,7 @@ function _importexprs(mod::ROSSrvModule, rosrootmod::Module)
         Expr(:import, :RobotOS, :_srv_reqtype),
         Expr(:import, :RobotOS, :_srv_resptype),
     ]
-    append!(imports, [Expr(:using,Symbol(rosrootmod),Symbol(m),:msg) for m in mod.deps])
+    append!(imports, [Expr(:using,fullname(rosrootmod)...,Symbol(m),:msg) for m in mod.deps])
     imports
 end
 

--- a/test/rospy.jl
+++ b/test/rospy.jl
@@ -4,7 +4,7 @@ init_node("jltest", anonymous=true)
 #Parameters
 @test length(RobotOS.get_param_names()) > 0
 @test has_param("rosdistro")
-@test chomp(get_param("rosdistro")) in ["hydro", "indigo", "jade", "kinetic", "lunar"]
+@test chomp(get_param("rosdistro")) in ["hydro", "indigo", "jade", "kinetic", "lunar", "melodic"]
 @test ! has_param("some_param")
 @test_throws KeyError get_param("some_param")
 @test_throws KeyError delete_param("some_param")

--- a/test/typegeneration.jl
+++ b/test/typegeneration.jl
@@ -28,6 +28,16 @@ rostypegen()
 @test isdefined(nav_msgs.srv, :GetPlanRequest)
 @test isdefined(nav_msgs.srv, :GetPlanResponse)
 
+#type generation in a non-Main module
+module TestModule
+    using RobotOS
+    @rosimport std_msgs.msg: Float32
+    rostypegen(current_module())
+end
+@test !isdefined(std_msgs.msg, :Float32Msg)
+@test isdefined(TestModule, :std_msgs)
+@test isdefined(TestModule.std_msgs.msg, :Float32Msg)
+
 #message creation
 posestamp = geometry_msgs.msg.PoseStamped()
 @test typeof(posestamp.pose) == geometry_msgs.msg.Pose


### PR DESCRIPTION
I've included the relevant doc change below. This commit also includes testing support for ROS Melodic.

I'll make another PR shortly that incorporates this commit and provides compatibility for Julia 0.7. There have been a decent number of changes to `Expr` syntax between 0.6 and 0.7, so instead of adding a bunch of `if VERSION < v"0.7.0"` statements I'm thinking that we drop support for 0.6 on master (a course many other Julia developers seem to be doing with the 0.7 update). That is, if this PR seems acceptable, this can be the last `RobotOS` 0.6 release, and we'll make a feature-equivalent 0.7 release that supports only Julia 0.7+. What do you think?

----

### Compatibility with Package Precompilation
As described above, by default `rostypegen` creates modules in `Main` -- however,
this behavior is incompatible with Julia package precompilation. If you are using
`RobotOS` in the context of a module, as opposed to a script, you may reduce
load-time latency (useful for real-life applications!) by generating the ROS type
modules inside your package module using an approach similar to the example below:

    # MyROSPackage.jl
    __precompile__()
    module MyROSPackage

    using RobotOS

    @rosimport geometry_msgs.msg: Pose
    rostypegen(current_module())
    import .geometry_msgs.msg: Pose
    # ...

    end

In this case, we have provided `rostypegen` with a root module (`MyROSPackage`)
for type generation. The Julia type corresponding to `geometry_msgs/Pose` now
lives at `MyROSPackage.geometry_msgs.msg.Pose`; note the extra dot in
`import .geometry_msgs.msg: Pose`.