### PR TITLE
Replace REQUIRE with Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,0 +1,16 @@
+name = "RobotOS"
+uuid = "22415677-39a4-5241-a37a-00beabbbdae8"
+version = "0.7.1"
+
+[deps]
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+
+[compat]
+PyCall = "≥ 1.90.0"
+julia = "≥ 0.7.0"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,0 @@
-julia 0.7
-PyCall 1.90.0


### PR DESCRIPTION
Apparently attobot no longer exists for tagging new package versions so this is an experiment in following the instructions here: https://github.com/JuliaRegistries/Registrator.jl#transitioning-from-require-to-projecttoml. Theoretically, after merging this PR, to release a new version (0.7.1) all you'll have to do is install Registrator and comment "@JuliaRegistrator register()" on the PR merge commit.