### PR TITLE
Add shutdown method for Service object

### DIFF
--- a/src/services.jl
+++ b/src/services.jl
@@ -1,5 +1,5 @@
 #API for calling/creating services. Syntax is practically identical to rospy.
-export Service, ServiceProxy, wait_for_service
+export Service, ServiceProxy, wait_for_service, shutdown
 
 """
     ServiceProxy{T}(name; kwargs...)
@@ -89,4 +89,8 @@ function wait_for_service(service::AbstractString; kwargs...)
     catch ex
         error("Timeout exceeded waiting for service '$service'")
     end
+end
+
+function shutdown(s::Service{ST}) where ST <: AbstractService
+    pycall(s.srv_obj["shutdown"], Nothing)
 end

--- a/src/services.jl
+++ b/src/services.jl
@@ -91,6 +91,10 @@ function wait_for_service(service::AbstractString; kwargs...)
     end
 end
 
+"""
+    shutdown(service_obj)
+Shut down the specified service.
+"""
 function shutdown(s::Service{ST}) where ST <: AbstractService
     pycall(s.srv_obj["shutdown"], Nothing)
 end

--- a/src/services.jl
+++ b/src/services.jl
@@ -96,5 +96,5 @@ end
 Shut down the specified service.
 """
 function shutdown(s::Service{ST}) where ST <: AbstractService
-    pycall(s.srv_obj["shutdown"], Nothing)
+    pycall(s.srv_obj.shutdown, Nothing)
 end

--- a/test/services.jl
+++ b/test/services.jl
@@ -50,6 +50,10 @@ if flag[1]
 end
 empty!(msgs)
 
+##Check the service is properly shut down
+srv_fake = Service("fake", SetBool, (req)->SetBoolResponse())
+@test shutdown(srv_fake) == nothing
+
 #Test error handling
 @test_throws ErrorException wait_for_service("fake_srv", timeout=1.0)
 @test_throws ArgumentError srvcall(SetBoolResponse())


### PR DESCRIPTION
I added shutdown method for service object. Without this, one has to restart a Julia session all the time when the callback function of a Service is modified, which is time-consuming because compilation will start over again.