### PR TITLE
Restructure some typegen code to fix break in 1.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,20 @@ matrix:
   allow_failures:
     - julia: nightly
 sudo: required
-dist: xenial
+dist: bionic
 env:
   global:
     - PYTHON=python
 before_install:
-  - sudo apt-add-repository -y "deb http://packages.ros.org/ros/ubuntu xenial main"
-  - wget https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -O - | sudo apt-key add -
+  - sudo apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+  - sudo apt-add-repository -y "deb http://packages.ros.org/ros/ubuntu bionic main"
   - sudo apt-get update
-  - sudo apt-get -y install ros-kinetic-ros-base ros-kinetic-common-msgs
+  - sudo apt-get -y install python-rosdep ros-melodic-ros-base ros-melodic-common-msgs
   - sudo rosdep init
   - rosdep update
 before_script:
   - export PATH=/usr/bin:$PATH
-  - source /opt/ros/kinetic/setup.sh
+  - source /opt/ros/melodic/setup.sh
   - roscore &
   - sleep 5
   - python test/echonode.py &

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: julia
 julia:
   - 1.0
-  - 1.2
+  - 1.5
   - nightly
 matrix:
   allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "RobotOS"
 uuid = "22415677-39a4-5241-a37a-00beabbbdae8"
-version = "0.7.1"
+version = "0.8.0"
 
 [deps]
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"

--- a/test/rospy.jl
+++ b/test/rospy.jl
@@ -6,7 +6,7 @@ init_node("jltest", anonymous=true)
 #Parameters
 @test length(RobotOS.get_param_names()) > 0
 @test has_param("rosdistro")
-@test chomp(get_param("rosdistro")) in ["hydro", "indigo", "jade", "kinetic", "lunar", "melodic"]
+@test chomp(get_param("rosdistro")) in ["kinetic", "melodic", "noetic"]
 @test ! has_param("some_param")
 @test_throws KeyError get_param("some_param")
 @test_throws KeyError delete_param("some_param")


### PR DESCRIPTION
As reported in #82, the code that used hardcoded accessing into `Expr` objects broke in julia 1.5 due to the internals of the expressions being represented differently. This gets around it by avoiding accessing `Expr` internals at all, preferring to splice the generated expressions where they are needed.

This also modifies travis to run on ubuntu 18.04 and ROS melodic and bumps the version to 0.8.