### PR TITLE
Updates to make new registered versions go through automatically

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "RobotOS"
 uuid = "22415677-39a4-5241-a37a-00beabbbdae8"
-version = "0.8.0"
+version = "0.7.2"
 
 [deps]
 PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 
 [compat]
-PyCall = "≥ 1.90.0"
-julia = "≥ 1"
+PyCall = "1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/RobotOS.jl
+++ b/src/RobotOS.jl
@@ -31,9 +31,11 @@ function __init__()
     try
         copy!(__rospy__, pyimport("rospy"))
     catch ex
-        if (isa(ex, PyCall.PyError) &&
-            pycall(pybuiltin("str"), PyAny, ex.val) == "No module named rospy")
-            error("rospy not found!\nHas an environment setup script been run?")
+        if (isa(ex, PyCall.PyError) && ex.T.__name__ == "ModuleNotFoundError")
+            @error """
+                Unable to load the 'rospy' python package!
+                Has an environment setup script been run?
+                """
         else
             rethrow(ex)
         end


### PR DESCRIPTION
- `compat` fields now have (implicit) upper-bounds
- The main `__init__` function no longer throws an exception if rospy isn't found but outputs an error message instead